### PR TITLE
Add placeholder adaptive launcher icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Added
 - Added `gradle.properties` enabling AndroidX and Jetifier.
+- Added placeholder adaptive launcher icons.
 
 ### Changed
 - Removed `package` attribute from manifest and marked `MainActivity` as exported.

--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,4 @@
 
 - Expand documentation sections with detailed guides as features are implemented.
 - Add CI check to validate manifest exported attributes.
+- Replace placeholder launcher icons with final design.

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <solid android:color="#3DDC84" />
+</shape>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M38,31 L38,77 77,54 Z"/>
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>


### PR DESCRIPTION
**Summary**
Adds basic adaptive launcher icon resources.

**Changes**
- Create empty `drawable` and `mipmap-anydpi-v26` directories.
- Add placeholder adaptive launcher icons (colored background with white triangle).
- Update changelog and TODO.

**Docs**
- n/a

**Changelog**
- Updated [Unreleased] section in CHANGELOG.

**Test Plan**
- `gradle -q help`
- Build and install on Android device; verify launcher icon shows green background with white triangle.

**Risks**
- Placeholder icons may not represent final branding.

**Rollback**
- Revert the commit.

**Sync / Touched files / Overlap notice**
- Touched: `app/src/main/res/drawable/*`, `app/src/main/res/mipmap-anydpi-v26/*`, `CHANGELOG.md`, `TODO.md`
- No overlap.

**Checklist**
- ✅ tests
- ✅ docs
- ✅ changelog
- ✅ formatting
- ✅ CI green


------
https://chatgpt.com/codex/tasks/task_b_68c3d65d56588324a51fb043a8ad71d3