### PR TITLE
fix: externalize accessibility description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Removed `package` attribute from manifest and marked `MainActivity` as exported.
 
+### Fixed
+- Resolved AAPT build error by externalizing accessibility service description.
+
 ### Docs
 - Added user manual skeleton with build and run instructions and linked docs from README.
 - Documented AndroidX and Jetifier build requirements.

--- a/TODO.md
+++ b/TODO.md
@@ -4,3 +4,4 @@
 - Add CI check to validate manifest exported attributes.
 - Replace placeholder launcher icons with final design.
 - Add screenshots for quickstart and UI guide.
+- Localize user-visible strings, including accessibility descriptions.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="accessibility_description">Track active app to block games during REST</string>
+</resources>

--- a/app/src/main/res/xml/accessibility_config.xml
+++ b/app/src/main/res/xml/accessibility_config.xml
@@ -5,4 +5,4 @@
     android:notificationTimeout="100"
     android:canRetrieveWindowContent="true"
     android:accessibilityFlags="flagReportViewIds|flagIncludeNotImportantViews"
-    android:description="Track active app to block games during REST"/>
+    android:description="@string/accessibility_description"/>


### PR DESCRIPTION
## Summary
Fix AAPT resource error by moving accessibility service description to a string resource.

## Changes
- add string resource for accessibility service description
- reference string in `accessibility_config.xml`
- note fix in changelog and todo

## Docs
- n/a

## Changelog
- see `CHANGELOG.md` under `[Unreleased]`

## Test Plan
- `gradle assembleDebug` *(fails: SDK location not found; environment missing Android SDK, but no AAPT error observed)*

## Risks
- misreferenced resource may break accessibility service

## Rollback
- revert commit

## Sync / Touched files / Overlap notice
- `app/src/main/res/values/strings.xml`
- `app/src/main/res/xml/accessibility_config.xml`
- `CHANGELOG.md`
- `TODO.md`

## Checklist
- [ ] tests
- [ ] docs
- [x] changelog
- [ ] formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c3d96d1ed08324823ccda3923df4c4