### PR TITLE
Switch theme to MaterialComponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Added `gradle.properties` enabling AndroidX and Jetifier.
 - Added placeholder adaptive launcher icons.
-- Introduced Material3 day/night theme and color palette.
+- Introduced day/night theme and color palette.
 - Added base `.editorconfig` and `.gitattributes` for consistent formatting.
 
 ### Changed
 - Removed `package` attribute from manifest and marked `MainActivity` as exported.
 - Set Java and Kotlin compilation targets to version 17.
+- Switched app theme to inherit from `Theme.MaterialComponents.DayNight.NoActionBar`.
 
 ### Fixed
 - Resolved AAPT build error by externalizing accessibility service description.

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,5 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Theme.ScreenCycle" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Theme.ScreenCycle" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorOnPrimary">@color/colorOnPrimary</item>
         <item name="colorPrimaryContainer">@color/colorPrimaryContainer</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <style name="Theme.ScreenCycle" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="Theme.ScreenCycle" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorOnPrimary">@color/colorOnPrimary</item>
         <item name="colorPrimaryContainer">@color/colorPrimaryContainer</item>


### PR DESCRIPTION
## Summary
- switch app theme parent to Theme.MaterialComponents.DayNight.NoActionBar
- update changelog for theme change

## Changes
- replace Material3 theme parent with MaterialComponents in light and night theme resources
- document theme switch in changelog

## Docs
- n/a

## Changelog
- see `CHANGELOG.md`

## Test Plan
- `gradle assembleDebug test` *(fails: SDK location not found)*

## Risks
- potential UI differences due to theme change

## Rollback
- `git revert e316a4c`

## Sync / Touched files / Overlap notice
- app/src/main/res/values
- app/src/main/res/values-night
- CHANGELOG.md

## Checklist
- [ ] tests
- [ ] docs
- [x] changelog
- [x] formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c3f0bbe5c083248cbc6f45d30cb430