### PR TITLE
test: add MainActivity launch instrumentation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added placeholder adaptive launcher icons.
 - Introduced day/night theme and color palette.
 - Added base `.editorconfig` and `.gitattributes` for consistent formatting.
+- Added instrumented test to verify `MainActivity` launches without exceptions.
 
 ### Changed
 - Removed `package` attribute from manifest and marked `MainActivity` as exported.

--- a/TODO.md
+++ b/TODO.md
@@ -8,3 +8,4 @@
 - Add CI check for required JDK/JVM version.
 - Ensure Android SDK platform 34 and build-tools 34 are installed and licenses accepted for builds.
 - Enhance theme with dynamic color support and custom palettes.
+- Expand instrumented UI tests to cover additional user flows.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,4 +40,8 @@ dependencies {
     implementation 'androidx.activity:activity-ktx:1.9.1'
     implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'androidx.work:work-runtime-ktx:2.9.1'
+
+    androidTestImplementation 'androidx.test:core:1.6.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/src/androidTest/java/com/example/screencycle/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/example/screencycle/ui/MainActivityTest.kt
@@ -1,0 +1,14 @@
+package com.example.screencycle.ui
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+    @Test
+    fun launchMainActivity() {
+        ActivityScenario.launch(MainActivity::class.java).use { }
+    }
+}


### PR DESCRIPTION
## Summary
- add instrumentation test to ensure MainActivity launches without exceptions
- configure androidTest dependencies
- record addition in changelog and todo

## Changes
- add `MainActivityTest` using `ActivityScenario`
- add AndroidX test dependencies in Gradle
- update CHANGELOG and TODO

## Docs
- n/a

## Changelog
- [Unreleased] Added instrumented test to verify MainActivity launches without exceptions.

## Test Plan
- `gradle connectedAndroidTest` *(fails: SDK location not found)*

## Risks
- instrumentation tests require a configured Android SDK and device/emulator

## Rollback
- Revert this PR

## Sync / Touched files / Overlap notice
- `app/src/androidTest/...`
- `app/build.gradle`
- `CHANGELOG.md`
- `TODO.md`

## Checklist
- ✅ tests *(attempted)*
- ✅ docs *(n/a)*
- ✅ changelog
- ✅ formatting
- ⚠️ CI green *(requires environment with Android SDK)*

------
https://chatgpt.com/codex/tasks/task_b_68c3f1848ee4832497a82fe531ffbf43