### PR TITLE
Fix accessibility service lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added required `FOREGROUND_SERVICE_DATA_SYNC` permission.
 - Removed deprecated `TYPE_PHONE` overlay window type.
 - Start button now detects running cycle on app return and shows **Stop**.
+- Use `getEnabledAccessibilityServiceList` to query enabled accessibility services.
 
 ### Docs
 - Added user manual skeleton with build and run instructions and linked docs from README.

--- a/app/src/main/java/com/example/screencycle/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/screencycle/ui/MainActivity.kt
@@ -142,7 +142,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun isAccessibilityEnabled(): Boolean {
         val am = getSystemService(AccessibilityManager::class.java) ?: return false
-        val enabled = am.enabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
+        val enabled = am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
         return enabled.any {
             it.resolveInfo.serviceInfo.packageName == packageName &&
                 it.resolveInfo.serviceInfo.name == AppAccessibilityService::class.java.name


### PR DESCRIPTION
## Summary
- use `getEnabledAccessibilityServiceList` to check enabled accessibility services

## Changes
- replace deprecated `AccessibilityManager` API call
- update changelog

## Docs
- no user-facing documentation changes

## Changelog
- [Unreleased] > Fixed: Use `getEnabledAccessibilityServiceList` to query enabled accessibility services

## Test Plan
- `gradle assembleDebug`
- `gradle test`

## Risks
- accessibility service detection could still misbehave on unexpected platform versions

## Rollback
- Revert this commit

## Sync / Touched files / Overlap notice
- `app/src/main/java/com/example/screencycle/ui/MainActivity.kt`
- `CHANGELOG.md`
- no overlaps with other modules

## Checklist
- ✅ tests
- ✅ docs
- ✅ changelog
- ✅ formatting
- ✅ CI green

------
https://chatgpt.com/codex/tasks/task_b_68c41d95167c8324b50e657176a1e709