### PR TITLE
Add MainActivity instrumentation tests for permissions and service control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Introduced day/night theme and color palette.
 - Added base `.editorconfig` and `.gitattributes` for consistent formatting.
 - Added instrumented test to verify `MainActivity` launches without exceptions.
+- Added instrumented tests for permission dialog and service start/stop.
 - Added `SettingsRepository` using DataStore for durations and blocked packages.
 - Added main screen counter showing number of selected apps.
 - Cycle service now broadcasts remaining time every second and updates notification and UI.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,4 +46,5 @@ dependencies {
     androidTestImplementation 'androidx.test:core:1.6.1'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'io.mockk:mockk-android:1.13.10'
 }

--- a/app/src/androidTest/java/com/example/screencycle/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/example/screencycle/ui/MainActivityTest.kt
@@ -1,14 +1,107 @@
 package com.example.screencycle.ui
 
+import android.app.ActivityManager
+import android.os.PowerManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.screencycle.R
+import com.example.screencycle.core.CycleService
+import com.example.screencycle.core.Permissions
+import com.example.screencycle.core.SettingsRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.security.MessageDigest
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class MainActivityTest {
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        runBlocking {
+            SettingsRepository(context).setPinHash(hash("1234"))
+        }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
     @Test
     fun launchMainActivity() {
-        ActivityScenario.launch(MainActivity::class.java).use { }
+        ActivityScenario.launch(MainActivity::class.java).use {
+            enterPin()
+        }
+    }
+
+    @Test
+    fun missingPermissions_showsDialog() {
+        mockkObject(Permissions)
+        every { Permissions.allGranted(any()) } returns false
+        every { Permissions.canDrawOverlays(any()) } returns false
+        every { Permissions.hasUsageStats(any()) } returns true
+        every { Permissions.isAccessibilityEnabled(any()) } returns true
+
+        ActivityScenario.launch(MainActivity::class.java).use {
+            enterPin()
+            onView(withId(R.id.btnStart)).perform(click())
+            onView(withText(R.string.missing_overlay)).check(matches(isDisplayed()))
+        }
+    }
+
+    @Test
+    fun startStopButton_controlsService() {
+        mockkObject(Permissions)
+        every { Permissions.allGranted(any()) } returns true
+        every { Permissions.canDrawOverlays(any()) } returns true
+        every { Permissions.hasUsageStats(any()) } returns true
+        every { Permissions.isAccessibilityEnabled(any()) } returns true
+
+        val pm = mockk<PowerManager>()
+        every { pm.isIgnoringBatteryOptimizations(any()) } returns true
+
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { it.powerManagerOverride = pm }
+            enterPin()
+            onView(withId(R.id.btnStart)).perform(click())
+            assertTrue(isServiceRunning())
+            onView(withId(R.id.btnStart)).perform(click())
+            assertFalse(isServiceRunning())
+        }
+    }
+
+    private fun enterPin() {
+        onView(withId(R.id.etPin)).perform(typeText("1234"), closeSoftKeyboard())
+        onView(withId(R.id.btnPinOk)).perform(click())
+    }
+
+    private fun isServiceRunning(): Boolean {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val am = context.getSystemService(ActivityManager::class.java)
+        val services = am.getRunningServices(Int.MAX_VALUE)
+        return services.any { it.service.className == CycleService::class.java.name }
+    }
+
+    private fun hash(pin: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(pin.toByteArray())
+        return digest.joinToString("") { "%02x".format(it) }
     }
 }

--- a/app/src/main/java/com/example/screencycle/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/screencycle/ui/MainActivity.kt
@@ -21,6 +21,7 @@ import com.example.screencycle.core.CycleService
 import com.example.screencycle.core.Permissions
 import com.example.screencycle.core.SettingsRepository
 import kotlinx.coroutines.launch
+import androidx.annotation.VisibleForTesting
 
 class MainActivity : AppCompatActivity() {
     private val settings by lazy { SettingsRepository(this) }
@@ -28,6 +29,9 @@ class MainActivity : AppCompatActivity() {
     private lateinit var tvTimer: TextView
     private lateinit var btnStart: Button
     private var cycleRunning = false
+
+    @VisibleForTesting
+    var powerManagerOverride: PowerManager? = null
 
     private var pinVerified = false
     private val pinLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
@@ -125,7 +129,7 @@ class MainActivity : AppCompatActivity() {
             PermissionsDialogFragment().show(supportFragmentManager, "perm")
             return false
         }
-        val pm = getSystemService(PowerManager::class.java)
+        val pm = powerManagerOverride ?: getSystemService(PowerManager::class.java)
         if (pm != null && !pm.isIgnoringBatteryOptimizations(packageName)) {
             try {
                 startActivity(

--- a/docs/contrib/android.md
+++ b/docs/contrib/android.md
@@ -1,0 +1,24 @@
+# Android contribution guide
+
+## Supported tools
+- Android Studio Giraffe or newer
+- Gradle 8.x
+- JDK/Kotlin 17
+
+## Tests
+Run instrumented tests on an emulator or device:
+```bash
+./gradlew connectedAndroidTest
+```
+
+## CI
+No dedicated CI. Run tests locally before pushing.
+
+## Secrets
+None required for local development.
+
+## CLI help
+List available Gradle tasks:
+```bash
+./gradlew tasks
+```


### PR DESCRIPTION
## Summary
- add instrumentation tests for permission dialog and service start/stop
- allow injecting PowerManager for tests and add MockK dependency
- document Android contribution guidelines

## Changes
- add `MainActivityTest` verifying permission dialog and service control
- support PowerManager override in `MainActivity`
- include mockk-android for instrumentation tests
- add `docs/contrib/android.md`

## Docs
- `docs/contrib/android.md`

## Changelog
- Added instrumented tests for permission dialog and service start/stop.

## Test Plan
- `gradle lint` *(fails: SDK location not found)*
- `./gradlew connectedAndroidTest` *(fails: gradle wrapper missing)*
- `gradle connectedAndroidTest` *(fails: SDK location not found)*

## Risks
- None identified beyond usual Android test setup.

## Rollback
- Revert this commit.

## Checklist
- [ ] Tests
- [x] Docs
- [x] Changelog
- [ ] Formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c7c5588fdc832481c2419e9f4ec4cc