### PR TITLE
Finalize adaptive launcher icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Added PIN screen requiring verification before accessing settings.
 - Added `gradle.properties` enabling AndroidX and Jetifier.
-- Added placeholder adaptive launcher icons.
 - Introduced day/night theme and color palette.
 - Added base `.editorconfig` and `.gitattributes` for consistent formatting.
 - Added instrumented test to verify `MainActivity` launches without exceptions.
@@ -30,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Start button toggles between "Working..." and "Stop" while the cycle runs.
 - Permissions dialog now handles battery optimization exemption; duplicate logic removed from `MainActivity`.
 - Refined instrumented tests to assert `PermissionsDialogFragment` visibility and verify service start/stop state via `ActivityScenario`.
+- Finalized adaptive launcher icons and moved them to mipmap resources.
 
 ### Removed
 - Removed legacy `Prefs` helper based on `SharedPreferences`.

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-    <solid android:color="#3DDC84" />
-</shape>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <background android:drawable="@mipmap/ic_launcher_background" />
+    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@drawable/ic_launcher_background" />
-    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <background android:drawable="@mipmap/ic_launcher_background" />
+    <foreground android:drawable="@mipmap/ic_launcher_foreground" />
 </adaptive-icon>

--- a/app/src/main/res/mipmap/ic_launcher_background.xml
+++ b/app/src/main/res/mipmap/ic_launcher_background.xml
@@ -5,6 +5,6 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="#FFFFFFFF"
-        android:pathData="M38,31 L38,77 77,54 Z"/>
+        android:fillColor="#1E88E5"
+        android:pathData="M0,0h108v108h-108z" />
 </vector>

--- a/app/src/main/res/mipmap/ic_launcher_foreground.xml
+++ b/app/src/main/res/mipmap/ic_launcher_foreground.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M54 27V13.5L36 31.5l18 18V36c14.895 0 27 12.105 27 27s-12.105 27-27 27-27-12.105-27-27H18c0 19.845 16.155 36 36 36s36-16.155 36-36-16.155-36-36-36z" />
+</vector>


### PR DESCRIPTION
## Summary
- replace temporary launcher assets with final adaptive icons
- point adaptive icon definitions to mipmap resources

## Changes
- add final foreground/background vectors under `mipmap`
- update adaptive icon XML to reference mipmap drawables

## Docs
- n/a

## Changelog
- `CHANGELOG.md`

## Test Plan
- `gradle lint` *(fails: SDK location not found)*

## Risks
- none identified

## Rollback
- revert commit `feat: finalize adaptive launcher icons`

## Checklist
- [ ] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c7fcac22108324bb146ff42792ca5c