### PR TITLE
Add Russian localization test and update translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Cycle service now broadcasts remaining time every second and updates notification and UI.
 - Introduced `BlockActivity` to display a full-screen rest screen.
 - Dialog prompting to enable accessibility service when disabled.
+- Localization unit test ensuring Russian strings match the default locale.
 
 ### Changed
 - Removed `package` attribute from manifest and marked `MainActivity` as exported.
@@ -30,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Permissions dialog now handles battery optimization exemption; duplicate logic removed from `MainActivity`.
 - Refined instrumented tests to assert `PermissionsDialogFragment` visibility and verify service start/stop state via `ActivityScenario`.
 - Finalized adaptive launcher icons and moved them to mipmap resources.
+- Updated Russian translations for accessibility description and battery optimization dialog.
 
 ### Removed
 - Removed legacy `Prefs` helper based on `SharedPreferences`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation 'androidx.datastore:datastore-preferences:1.1.1'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
 
+    testImplementation 'junit:junit:4.13.2'
+
     androidTestImplementation 'androidx.test:core:1.6.1'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">ScreenCycle</string>
-    <string name="accessibility_description">Отслеживает активное приложение, чтобы блокировать игры во время отдыха</string>
+    <string name="accessibility_description">Отслеживает активные приложения, чтобы блокировать игры во время отдыха</string>
     <string name="rest_now">Сейчас отдых</string>
     <string name="start">Старт</string>
     <string name="stop">Стоп</string>
-    <string name="working">Запуск...</string>
+    <string name="working">Работает...</string>
     <string name="select_games">Выбрать игры</string>
     <string name="selected_games_none">Выбрано игр: 0</string>
     <string name="selected_games_count">Выбрано игр: %1$d</string>
@@ -18,7 +18,7 @@
     <string name="missing_overlay">Требуется разрешение поверх других окон.</string>
     <string name="missing_usage_stats">Нужен доступ к статистике использования.</string>
     <string name="missing_accessibility">Сервис доступности отключен.</string>
-    <string name="missing_battery_optimization">Приложение должно быть исключено из оптимизации батареи.</string>
+    <string name="missing_battery_optimization">Отключите оптимизацию батареи для ScreenCycle.</string>
     <string name="open_settings">Открыть настройки</string>
     <string name="icon">иконка</string>
     <string name="service_started">Запущено</string>

--- a/app/src/test/java/com/example/screencycle/LocalizationTest.kt
+++ b/app/src/test/java/com/example/screencycle/LocalizationTest.kt
@@ -1,0 +1,31 @@
+package com.example.screencycle
+
+import org.junit.Test
+import org.junit.Assert.assertTrue
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class LocalizationTest {
+    @Test
+    fun ruLocaleHasAllStrings() {
+        val baseFile = File("src/main/res/values/strings.xml")
+        val ruFile = File("src/main/res/values-ru/strings.xml")
+        val factory = DocumentBuilderFactory.newInstance()
+        val baseDoc = factory.newDocumentBuilder().parse(baseFile)
+        val ruDoc = factory.newDocumentBuilder().parse(ruFile)
+        val baseNames = baseDoc.getElementsByTagName("string")
+        val baseSet = (0 until baseNames.length)
+            .map { baseNames.item(it).attributes.getNamedItem("name").nodeValue }
+            .toSet()
+        val ruNames = ruDoc.getElementsByTagName("string")
+        val ruSet = (0 until ruNames.length)
+            .map { ruNames.item(it).attributes.getNamedItem("name").nodeValue }
+            .toSet()
+        val missingInRu = baseSet - ruSet
+        val missingInBase = ruSet - baseSet
+        assertTrue(
+            "Missing in ru: $missingInRu, missing in base: $missingInBase",
+            missingInRu.isEmpty() && missingInBase.isEmpty()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- verify Russian translations via unit test
- refine Russian accessibility and dialog text translations

## Changes
- add `LocalizationTest` checking parity between default and Russian strings
- add JUnit dependency for unit tests
- polish Russian strings for accessibility description and battery optimization

## Docs
- n/a

## Changelog
- Added: Localization unit test ensuring Russian strings match the default locale
- Changed: Updated Russian translations for accessibility description and battery optimization dialog

## Test Plan
- `gradle test` *(fails: SDK location not found)*
- `gradle lint` *(fails: SDK location not found)*

## Risks
- minimal: affects only localization resources and tests

## Rollback
- revert this PR

## Checklist
- [x] tests
- [ ] docs
- [x] changelog
- [x] formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c7fe0a2ba88324b7d4a36a720edf0d