### PR TITLE
fix: declare overlay permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Removed deprecated `TYPE_PHONE` overlay window type.
 - Start button now detects running cycle on app return and shows **Stop**.
 - Use `getEnabledAccessibilityServiceList` to query enabled accessibility services.
+- Declared `SYSTEM_ALERT_WINDOW` permission so the app appears in overlay settings.
 
 ### Docs
 - Added user manual skeleton with build and run instructions and linked docs from README.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
         xmlns:tools="http://schemas.android.com/tools"
         tools:ignore="ProtectedPermissions"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
## Summary
- ensure ScreenCycle requests overlay permission so it appears in system overlay settings

## Changes
- add SYSTEM_ALERT_WINDOW permission to AndroidManifest

## Docs
- n/a

## Changelog
- Declared SYSTEM_ALERT_WINDOW permission so the app appears in overlay settings.

## Test Plan
- `gradle test` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*
- `gradle assembleDebug` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*
- `gradle connectedAndroidTest` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

## Risks
- none identified

## Rollback
- revert this commit

## Checklist
- [ ] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c80732eee483249d9a499955f80b2e