### PR TITLE
Allow requesting battery optimization exemption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Introduced `BlockActivity` to display a full-screen rest screen.
 - Dialog prompting to enable accessibility service when disabled.
 - Localization unit test ensuring Russian strings match the default locale.
+- Added permission to request ignoring battery optimizations.
 
 ### Changed
 - Removed `package` attribute from manifest and marked `MainActivity` as exported.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
         xmlns:tools="http://schemas.android.com/tools"
         tools:ignore="ProtectedPermissions"/>


### PR DESCRIPTION
## Summary
- permit the app to ask for battery optimization exemption

## Changes
- add `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` manifest permission

## Docs
- n/a

## Changelog
- Added permission to request ignoring battery optimizations.

## Test Plan
- `gradle assembleDebug`
- install on device and open Start; observe battery optimization exemption dialog

## Risks
- requires additional permission at runtime

## Rollback
- revert this commit

## Checklist
- [ ] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c80a62a9dc8324974ec5be9c0ebd1b