### PR TITLE
Switch MainActivity test assertions to JUnit Assert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Finalized adaptive launcher icons and moved them to mipmap resources.
 - Updated Russian translations for accessibility description and battery optimization dialog.
 - Consolidated permissions into a single screen listing all missing requirements.
+- Updated `MainActivity` instrumented test assertions to use `org.junit.Assert` APIs.
 
 ### Removed
 - Removed legacy `Prefs` helper based on `SharedPreferences`.

--- a/app/src/androidTest/java/com/example/screencycle/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/example/screencycle/ui/MainActivityTest.kt
@@ -27,8 +27,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.security.MessageDigest
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class MainActivityTest {


### PR DESCRIPTION
## Summary
- Ensure the MainActivity instrumentation test relies on JUnit's assertion APIs for compatibility

## Changes
- Replace kotlin.test assertion imports with org.junit.Assert equivalents in MainActivityTest
- Document the assertion import switch in the Unreleased changelog

## Docs
- n/a

## Changelog
- Updated [Unreleased] → Changed: "Updated MainActivity instrumented test assertions to use org.junit.Assert APIs."

## Test Plan
- connectedAndroidTest → Fails (gradle wrapper script missing in repository, cannot execute)
- No UI-visible changes; manual verification not required

## Risks
- Low; only impacts test imports

## Rollback
- Revert this commit

## Checklist
- Tests: ⚠️ `./gradlew connectedAndroidTest` (gradle wrapper script missing)
- Docs: n/a
- Changelog: ✅
- Formatting: ✅
- CI: Pending


------
https://chatgpt.com/codex/tasks/task_b_68c92617c504832485f9cd2429c2521e