### PR TITLE
Exclude LICENSE metadata from androidTest packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Start button now detects running cycle on app return and shows **Stop**.
 - Use `getEnabledAccessibilityServiceList` to query enabled accessibility services.
 - Declared `SYSTEM_ALERT_WINDOW` permission so the app appears in overlay settings.
+- Excluded `/META-INF/LICENSE.md` from packaging to prevent resource merge conflicts during tests.
 
 ### Docs
 - Added user manual skeleton with build and run instructions and linked docs from README.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,11 @@ android {
     kotlinOptions {
         jvmTarget = '17'
     }
+    packaging {
+        resources {
+            excludes += "/META-INF/LICENSE.md"
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- exclude the duplicate META-INF license file from android test packaging

## Changes
- add an android packaging resources exclusion for `/META-INF/LICENSE.md`
- document the exclusion in the unreleased changelog fixes section

## Docs
- n/a

## Changelog
- updated `[Unreleased]` → Fixed in `CHANGELOG.md`

## Test Plan
- `gradle mergeDebugAndroidTestJavaResource` *(fails locally: Android SDK not configured; requires valid `sdk.dir` or `ANDROID_HOME`)*

## Risks
- Low: only adjusts packaging exclusions.

## Rollback
- Revert this commit.

## Checklist
- [ ] Tests
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c928fd6a7c8324bbac2cbba070247b