### PR TITLE
Replace LocalBroadcastManager usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Set Java and Kotlin compilation targets to version 17.
 - Switched app theme to inherit from `Theme.MaterialComponents.DayNight.NoActionBar`.
 - Replaced `Prefs` usage in activities and services with `SettingsRepository`.
-- Replaced global broadcasts with `LocalBroadcastManager`.
+- Switched cycle state delivery to in-app broadcasts registered via `ContextCompat.registerReceiver`.
 - `AppAccessibilityService` now returns to the home screen and launches `BlockActivity` during rest for selected packages or categories.
 - Cycle starts only when required permissions are granted.
 - Start button toggles between "Working..." and "Stop" while the cycle runs.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,6 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'androidx.work:work-runtime-ktx:2.9.1'
     implementation 'androidx.datastore:datastore-preferences:1.1.1'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
 
     testImplementation 'junit:junit:4.13.2'
 

--- a/app/src/main/java/com/example/screencycle/core/AppAccessibilityService.kt
+++ b/app/src/main/java/com/example/screencycle/core/AppAccessibilityService.kt
@@ -2,9 +2,10 @@ package com.example.screencycle.core
 
 import android.accessibilityservice.AccessibilityService
 import android.content.Intent
+import android.content.IntentFilter
 import android.view.accessibility.AccessibilityEvent
+import androidx.core.content.ContextCompat
 import kotlinx.coroutines.*
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.example.screencycle.ui.BlockActivity
 
 class AppAccessibilityService : AccessibilityService() {
@@ -42,9 +43,11 @@ class AppAccessibilityService : AccessibilityService() {
 
     override fun onCreate() {
         super.onCreate()
-        LocalBroadcastManager.getInstance(this).registerReceiver(
+        ContextCompat.registerReceiver(
+            this,
             stateReceiver,
-            android.content.IntentFilter(CycleService.ACTION_STATE)
+            IntentFilter(CycleService.ACTION_STATE),
+            ContextCompat.RECEIVER_NOT_EXPORTED
         )
         scope.launch {
             packages = settings.getBlockedPackages()
@@ -53,7 +56,7 @@ class AppAccessibilityService : AccessibilityService() {
     }
 
     override fun onDestroy() {
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(stateReceiver)
+        unregisterReceiver(stateReceiver)
         scope.cancel()
         super.onDestroy()
     }

--- a/app/src/main/java/com/example/screencycle/core/CycleService.kt
+++ b/app/src/main/java/com/example/screencycle/core/CycleService.kt
@@ -9,7 +9,6 @@ import android.content.Intent
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.example.screencycle.R
 import kotlinx.coroutines.*
 
@@ -75,8 +74,9 @@ class CycleService : Service() {
         val i = Intent(ACTION_STATE).apply {
             putExtra(EXTRA_REST, rest)
             putExtra(EXTRA_REMAINING, remaining)
+            setPackage(packageName)
         }
-        LocalBroadcastManager.getInstance(this).sendBroadcast(i)
+        sendBroadcast(i)
     }
 
     private fun notification(text: String): Notification =

--- a/app/src/main/java/com/example/screencycle/ui/BlockActivity.kt
+++ b/app/src/main/java/com/example/screencycle/ui/BlockActivity.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.core.content.ContextCompat
 import com.example.screencycle.R
 import com.example.screencycle.core.CycleService
 
@@ -27,14 +27,16 @@ class BlockActivity : AppCompatActivity() {
             android.view.WindowManager.LayoutParams.FLAG_FULLSCREEN
         )
         setContentView(R.layout.activity_block)
-        LocalBroadcastManager.getInstance(this).registerReceiver(
+        ContextCompat.registerReceiver(
+            this,
             stateReceiver,
-            IntentFilter(CycleService.ACTION_STATE)
+            IntentFilter(CycleService.ACTION_STATE),
+            ContextCompat.RECEIVER_NOT_EXPORTED
         )
     }
 
     override fun onDestroy() {
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(stateReceiver)
+        unregisterReceiver(stateReceiver)
         super.onDestroy()
     }
 }

--- a/app/src/main/java/com/example/screencycle/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/screencycle/ui/MainActivity.kt
@@ -11,8 +11,8 @@ import android.widget.Button
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.android.material.textfield.TextInputEditText
 import com.example.screencycle.R
 import com.example.screencycle.core.CycleService
@@ -106,9 +106,11 @@ class MainActivity : AppCompatActivity() {
         super.onStart()
         cycleRunning = isCycleServiceRunning()
         btnStart.text = if (cycleRunning) getString(R.string.stop) else getString(R.string.start)
-        LocalBroadcastManager.getInstance(this).registerReceiver(
+        ContextCompat.registerReceiver(
+            this,
             stateReceiver,
-            IntentFilter(CycleService.ACTION_STATE)
+            IntentFilter(CycleService.ACTION_STATE),
+            ContextCompat.RECEIVER_NOT_EXPORTED
         )
     }
 
@@ -127,7 +129,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onStop() {
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(stateReceiver)
+        unregisterReceiver(stateReceiver)
         super.onStop()
     }
 


### PR DESCRIPTION
## Summary
- replace the LocalBroadcastManager-based wiring with app-scoped broadcasts registered through ContextCompat
- align the accessibility service, block screen and main screen with the new registration approach
- drop the LocalBroadcastManager dependency

## Changes
- switch MainActivity, BlockActivity and AppAccessibilityService to ContextCompat.registerReceiver/unregisterReceiver
- have CycleService send package-scoped broadcasts via Context.sendBroadcast
- remove the androidx.localbroadcastmanager dependency and update the changelog entry

## Docs
- N/A

## Changelog
- [Unreleased]

## Test Plan
1. Launch the app, start a cycle and verify the timer updates while the service runs.
2. During a rest phase, open a blocked title and confirm BlockActivity appears and closes once play resumes.

## Risks
- Broadcast receivers might not be unregistered correctly, leading to leaks or missing updates.

## Rollback
- Revert this PR to restore LocalBroadcastManager usage.

## Checklist
- [ ] Tests (gradle wrapper missing locally)
- [ ] Docs (N/A)
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c92ae1f53083248977e5182a493978