### PR TITLE
Add instrumentation coverage for permissions and service toggling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added base `.editorconfig` and `.gitattributes` for consistent formatting.
 - Added instrumented test to verify `MainActivity` launches without exceptions.
 - Added instrumented tests for permission dialog and service start/stop.
+- Added `PermissionsAndStartStopTest` covering permissions list intents and cycle toggling.
 - Added `SettingsRepository` using DataStore for durations and blocked packages.
 - Added support for blocking app categories alongside packages.
 - Added screen to select app categories for blocking.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,5 +52,6 @@ dependencies {
     androidTestImplementation 'androidx.test:core:1.6.1'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.6.1'
     androidTestImplementation 'io.mockk:mockk-android:1.13.10'
 }

--- a/app/src/androidTest/java/com/example/screencycle/ui/PermissionsAndStartStopTest.kt
+++ b/app/src/androidTest/java/com/example/screencycle/ui/PermissionsAndStartStopTest.kt
@@ -1,0 +1,142 @@
+package com.example.screencycle.ui
+
+import android.app.Activity
+import android.app.ActivityManager
+import android.app.Instrumentation
+import android.net.Uri
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onData
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
+import androidx.test.espresso.intent.matcher.IntentMatchers.isInternal
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.screencycle.R
+import com.example.screencycle.core.CycleService
+import com.example.screencycle.core.Permissions
+import com.example.screencycle.core.SettingsRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.runBlocking
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.anything
+import org.hamcrest.Matchers.not
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.security.MessageDigest
+
+@RunWith(AndroidJUnit4::class)
+class PermissionsAndStartStopTest {
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        runBlocking {
+            SettingsRepository(context).setPinHash(hash("1234"))
+        }
+        Intents.init()
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+        PermissionsActivity.powerManagerOverride = null
+        unmockkAll()
+    }
+
+    @Test
+    fun permissionsActivity_showsMissingPermissionsAndLaunchesSettings() {
+        mockkObject(Permissions)
+        every { Permissions.canDrawOverlays(any()) } returns false
+        every { Permissions.hasUsageStats(any()) } returns false
+        every { Permissions.isAccessibilityEnabled(any()) } returns false
+
+        val pm = mockk<PowerManager>()
+        every { pm.isIgnoringBatteryOptimizations(any()) } returns false
+        PermissionsActivity.powerManagerOverride = pm
+
+        intending(not(isInternal())).respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
+
+        ActivityScenario.launch(PermissionsActivity::class.java).use {
+            onView(withId(R.id.permissions_list)).check(matches(isDisplayed()))
+            onView(withText(R.string.missing_overlay)).check(matches(isDisplayed()))
+            onView(withText(R.string.missing_usage_stats)).check(matches(isDisplayed()))
+            onView(withText(R.string.missing_accessibility)).check(matches(isDisplayed()))
+            onView(withText(R.string.missing_battery_optimization)).check(matches(isDisplayed()))
+
+            val packageUri = Uri.parse("package:${InstrumentationRegistry.getInstrumentation().targetContext.packageName}")
+
+            onData(anything()).atPosition(0).perform(click())
+            intended(allOf(hasAction(Settings.ACTION_MANAGE_OVERLAY_PERMISSION), hasData(packageUri)))
+
+            onData(anything()).atPosition(1).perform(click())
+            intended(hasAction(Settings.ACTION_USAGE_ACCESS_SETTINGS))
+
+            onData(anything()).atPosition(2).perform(click())
+            intended(hasAction(Settings.ACTION_ACCESSIBILITY_SETTINGS))
+
+            onData(anything()).atPosition(3).perform(click())
+            intended(allOf(hasAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS), hasData(packageUri)))
+        }
+    }
+
+    @Test
+    fun mainActivity_startStopButtonControlsService() {
+        mockkObject(Permissions)
+        every { Permissions.canDrawOverlays(any()) } returns true
+        every { Permissions.hasUsageStats(any()) } returns true
+        every { Permissions.isAccessibilityEnabled(any()) } returns true
+
+        val pm = mockk<PowerManager>()
+        every { pm.isIgnoringBatteryOptimizations(any()) } returns true
+
+        ActivityScenario.launch(MainActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                activity.powerManagerOverride = pm
+            }
+            enterPin()
+
+            onView(withId(R.id.btnStart)).perform(click())
+            scenario.onActivity { activity ->
+                val am = activity.getSystemService(ActivityManager::class.java)
+                val services = am.getRunningServices(Int.MAX_VALUE)
+                assertTrue(services.any { it.service.className == CycleService::class.java.name })
+            }
+
+            onView(withId(R.id.btnStart)).perform(click())
+            scenario.onActivity { activity ->
+                val am = activity.getSystemService(ActivityManager::class.java)
+                val services = am.getRunningServices(Int.MAX_VALUE)
+                assertFalse(services.any { it.service.className == CycleService::class.java.name })
+            }
+        }
+    }
+
+    private fun enterPin() {
+        onView(withId(R.id.etPin)).perform(typeText("1234"), closeSoftKeyboard())
+        onView(withId(R.id.btnPinOk)).perform(click())
+    }
+
+    private fun hash(pin: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(pin.toByteArray())
+        return digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/app/src/main/java/com/example/screencycle/ui/PermissionsActivity.kt
+++ b/app/src/main/java/com/example/screencycle/ui/PermissionsActivity.kt
@@ -8,6 +8,7 @@ import android.os.PowerManager
 import android.provider.Settings
 import android.widget.ArrayAdapter
 import android.widget.ListView
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import com.example.screencycle.R
 import com.example.screencycle.core.Permissions
@@ -31,7 +32,7 @@ class PermissionsActivity : AppCompatActivity() {
     }
 
     private fun rebuildList() {
-        val pm = getSystemService(PowerManager::class.java)
+        val pm = powerManagerOverride ?: getSystemService(PowerManager::class.java)
         items = collectMissingPermissions(this, pm)
         if (items.isEmpty()) {
             finish()
@@ -44,7 +45,13 @@ class PermissionsActivity : AppCompatActivity() {
     data class MissingPermission(val msgRes: Int, val intent: Intent)
 
     companion object {
-        fun collectMissingPermissions(ctx: Context, pm: PowerManager? = ctx.getSystemService(PowerManager::class.java)): List<MissingPermission> {
+        @VisibleForTesting
+        var powerManagerOverride: PowerManager? = null
+
+        fun collectMissingPermissions(
+            ctx: Context,
+            pm: PowerManager? = powerManagerOverride ?: ctx.getSystemService(PowerManager::class.java)
+        ): List<MissingPermission> {
             val missing = mutableListOf<MissingPermission>()
             if (!Permissions.canDrawOverlays(ctx)) {
                 missing += MissingPermission(


### PR DESCRIPTION
## Summary
- add instrumentation coverage for permissions listing and cycle service toggling

## Changes
- add PermissionsAndStartStopTest to validate permissions list entries and start/stop control
- allow overriding the PowerManager in PermissionsActivity for instrumentation
- include Espresso Intents dependency for androidTest builds

## Docs
- N/A

## Changelog
- CHANGELOG.md

## Test Plan
- Launch instrumentation suite and run `PermissionsAndStartStopTest.permissionsActivity_showsMissingPermissionsAndLaunchesSettings`; verify the permissions list shows every missing entry and tapping each launches the matching intent
- Launch instrumentation suite and run `PermissionsAndStartStopTest.mainActivity_startStopButtonControlsService`; verify tapping Start spins up CycleService and tapping Stop shuts it down

## Risks
- Low: production behaviour unchanged aside from a test-only override hook

## Rollback
- Revert this commit

## Checklist
- [x] Tests updated
- [ ] Docs updated
- [x] Changelog updated
- [x] Formatting passes
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c93bb20ef08324972ddde139690941