### PR TITLE
Add package visibility permission and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 ### Added
+- Declared package visibility permission and launcher queries to support app selection screen.
 - Added notification controls to adjust play and rest durations with instant updates and safe limits.
 - Added complete Russian localization for user-facing strings and accessibility copy.
 - Added PIN screen requiring verification before accessing settings.
@@ -62,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Excluded `/META-INF/LICENSE.md` from packaging to prevent resource merge conflicts during tests.
 
 ### Docs
+- Documented troubleshooting steps for package visibility permission.
 - Added user manual skeleton with build and run instructions and linked docs from README.
 - Documented AndroidX and Jetifier build requirements.
 - Added troubleshooting note about `android:exported` requirement on Android 12+.

--- a/app/src/androidTest/java/com/example/screencycle/core/PackageVisibilityTest.kt
+++ b/app/src/androidTest/java/com/example/screencycle/core/PackageVisibilityTest.kt
@@ -1,0 +1,25 @@
+package com.example.screencycle.core
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PackageVisibilityTest {
+
+    @Test
+    fun installedApplicationsListIncludesOtherPackages() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val packageManager = context.packageManager
+
+        val installedApps = packageManager.getInstalledApplications(0)
+        val otherPackages = installedApps.filter { it.packageName != context.packageName }
+
+        assertTrue(
+            "QUERY_ALL_PACKAGES permission should expose third-party apps, but only ${installedApps.map { it.packageName }} were visible.",
+            otherPackages.isNotEmpty()
+        )
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,15 @@
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
         xmlns:tools="http://schemas.android.com/tools"
         tools:ignore="ProtectedPermissions"/>
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
+    </queries>
 
     <application
         android:allowBackup="true"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,3 +3,9 @@
 ## Проект не собирается
 - Убедитесь, что в `gradle.properties` включены `android.useAndroidX=true` и `android.enableJetifier=true`.
 - На устройствах с Android 12 и выше проверьте, что в `AndroidManifest.xml` у `MainActivity` указано `android:exported="true"`.
+
+## Экран выбора приложений пустой
+- Приложению требуется разрешение `android.permission.QUERY_ALL_PACKAGES`, чтобы видеть установленные пакеты и категории, доступные для блокировки. Убедитесь, что разрешение объявлено в `AndroidManifest.xml` рядом с другими `uses-permission`.
+- Для публикации в Play Store можно ограничить видимость через `<queries>` и оставить только интенты `MAIN` + `LAUNCHER`, если глобальный доступ ко всем пакетам не нужен.
+- Проверить установку разрешения можно командой `adb shell dumpsys package com.example.screencycle | grep QUERY_ALL_PACKAGES` — в выводе должен появиться соответствующий флаг.
+- Дополнительно выполните инструментальный тест `./gradlew connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.example.screencycle.core.PackageVisibilityTest`, чтобы убедиться, что `getInstalledApplications(0)` возвращает больше одного пакета.


### PR DESCRIPTION
## Summary
- ensure the app enumerates installed packages needed for the blocklist picker

## Changes
- declare the QUERY_ALL_PACKAGES permission and launcher intent queries in the manifest
- add an instrumented assertion that getInstalledApplications() reveals additional packages
- document troubleshooting and verification steps for the package-visibility requirement

## Docs
- docs/troubleshooting.md

## Changelog
- Added entry under [Unreleased] → Added/Docs in CHANGELOG.md

## Test Plan
- gradle test *(fails: Android SDK not configured in container)*

## Risks
- Play Store distribution may require additional justification for QUERY_ALL_PACKAGES

## Rollback
- Revert this commit

## Checklist
- [ ] Tests *(Android SDK unavailable in container)*
- [x] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green

------
https://chatgpt.com/codex/tasks/task_b_68c957141970832487a8b0a7efbd107c