### PR TITLE
Collect blocked app settings via flows in accessibility service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Use `getEnabledAccessibilityServiceList` to query enabled accessibility services.
 - Declared `SYSTEM_ALERT_WINDOW` permission so the app appears in overlay settings.
 - Excluded `/META-INF/LICENSE.md` from packaging to prevent resource merge conflicts during tests.
+- Accessibility service now refreshes blocked apps and categories immediately after settings changes.
 
 ### Docs
 - Documented troubleshooting steps for package visibility permission.

--- a/app/src/main/java/com/example/screencycle/core/AppAccessibilityService.kt
+++ b/app/src/main/java/com/example/screencycle/core/AppAccessibilityService.kt
@@ -6,6 +6,7 @@ import android.content.IntentFilter
 import android.view.accessibility.AccessibilityEvent
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.collect
 import com.example.screencycle.ui.BlockActivity
 
 class AppAccessibilityService : AccessibilityService() {
@@ -50,8 +51,10 @@ class AppAccessibilityService : AccessibilityService() {
             ContextCompat.RECEIVER_NOT_EXPORTED
         )
         scope.launch {
-            packages = settings.getBlockedPackages()
-            categories = settings.getBlockedCategories()
+            settings.getBlockedPackagesFlow().collect { packages = it }
+        }
+        scope.launch {
+            settings.getBlockedCategoriesFlow().collect { categories = it }
         }
     }
 

--- a/app/src/main/java/com/example/screencycle/core/SettingsRepository.kt
+++ b/app/src/main/java/com/example/screencycle/core/SettingsRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.example.screencycle.R
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
@@ -36,12 +37,18 @@ class SettingsRepository(private val context: Context) {
     suspend fun getBlockedPackages(): Set<String> =
         dataStore.data.map { it[BLOCKED_PACKAGES] ?: emptySet() }.first()
 
+    fun getBlockedPackagesFlow(): Flow<Set<String>> =
+        dataStore.data.map { it[BLOCKED_PACKAGES] ?: emptySet() }
+
     suspend fun setBlockedCategories(categories: Set<String>) {
         dataStore.edit { it[BLOCKED_CATEGORIES] = categories }
     }
 
     suspend fun getBlockedCategories(): Set<String> =
         dataStore.data.map { it[BLOCKED_CATEGORIES] ?: emptySet() }.first()
+
+    fun getBlockedCategoriesFlow(): Flow<Set<String>> =
+        dataStore.data.map { it[BLOCKED_CATEGORIES] ?: emptySet() }
 
     suspend fun setPinHash(hash: String) {
         dataStore.edit { it[PIN_HASH] = hash }


### PR DESCRIPTION
## Summary
- keep the accessibility service in sync with blocked packages and categories by collecting DataStore flows

## Changes
- add flow accessors for blocked packages and categories in `SettingsRepository`
- collect the new flows inside `AppAccessibilityService` so cached sets refresh automatically
- record the behavior update in `CHANGELOG.md`

## Docs
- N/A

## Changelog
- CHANGELOG.md

## Test Plan
- Start a work/rest cycle with the accessibility service enabled.
- While rest mode is active, add a package to the blocked list in settings.
- Confirm the service immediately redirects the newly blocked app without restarting the cycle.
- Select an additional blocked category and verify apps in that category are redirected right away.

## Risks
- Low: touches flow collection logic in the accessibility service and DataStore accessors.

## Rollback
- Revert commit `5e5b902`.

## Checklist
- [ ] Tests (no Gradle wrapper present to run lint locally)
- [ ] Docs
- [x] Changelog
- [x] Formatting
- [ ] CI green


------
https://chatgpt.com/codex/tasks/task_b_68c95ef8e1908324bc0123293375059f